### PR TITLE
Fix a bug that opening a theme with the bot resulted in an error

### DIFF
--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -8,7 +8,7 @@ import EmptyWorkspace from "../EmptyWorkspace";
 import Header from "../Header";
 import React from "react";
 import Workspace from "../Workspace";
-import atthemeEditorApi from "attheme-editor-api/lib/browser";
+import * as atthemeEditorApi from "attheme-editor-api/lib/browser";
 import parseTheme from "../parseTheme";
 import parseWorkspace from "../parseWorkspace";
 import fromFile from "attheme-js/lib/tools/browser/fromFile";


### PR DESCRIPTION
When opening a theme with [@atthemeeditorbot], the editor ran into an error saying that `downloadTheme` was `undefined`. Surely it's a TypeScript bug that allowed previous code, but, nonetheless, it was erroneous.

[@atthemeeditorbot]: https://t.me/atthemeeditorbot