### PR TITLE
Fix build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "scripts": {
     "analyze": "npx source-map-explorer build/static/js/main.*",
-    "start": "react-scripts start",
-    "build": "react-scripts build"
+    "start": "react-scripts --max-old-space-size=2048 start",
+    "build": "react-scripts --max-old-space-size=2048 build"
   },
   "browserslist": {
     "development": [

--- a/src/HeaderTabs/variables.scss
+++ b/src/HeaderTabs/variables.scss
@@ -1,4 +1,4 @@
-@import "../header/variables";
+@import "../Header/variables";
 
 $tabs_height: $header_height;
 $tabs_iconSize: $tabs_height / 5 * 2;

--- a/src/Heading/index.tsx
+++ b/src/Heading/index.tsx
@@ -2,6 +2,9 @@ import "./styles.scss";
 
 import React from "react";
 
+// eslint-disable-next-line quotes
+type Levels = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
 interface Props {
   children: React.ReactNode;
   level: number;
@@ -14,7 +17,7 @@ export default class Heading extends React.Component<Props> {
   };
 
   render() {
-    const Level = `h${this.props.level}`;
+    const Level = `h${this.props.level}` as Levels;
 
     return (
       <Level className={`heading ${this.props.className}`}>

--- a/src/Logo/variables.scss
+++ b/src/Logo/variables.scss
@@ -1,5 +1,5 @@
 @import "../variables";
-@import "../header/variables";
+@import "../Header/variables";
 
 $logo_size: $header_height / 2;
 $logo_color: $theme_textColor;


### PR DESCRIPTION
Fixed a types-related error and casing in SCSS files. Also increased heap size to 2 GB for CRA because the default limit is not enough (at least on Ubuntu, as it worked normally on Windows before).